### PR TITLE
[SM-1117] Rename service accounts to machine accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To use the action, add a step to your GitHub workflow using the following syntax
 
 - `access_token`
 
-  The service account access token for retrieving secrets.
+  The machine account access token for retrieving secrets.
 
-  Use GitHub's [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to store and retrieve service account access tokens securely.
+  Use GitHub's [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) to store and retrieve machine account access tokens securely.
 
 - `secrets`
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: "blue"
 inputs:
   access_token:
-    description: "The service account access token for retrieving secrets"
+    description: "The machine account access token for retrieving secrets"
     required: true
   secrets:
     description: "One or more secret Ids to retrieve and the corresponding GitHub environment variable name to set"

--- a/dist/index.js
+++ b/dist/index.js
@@ -24791,7 +24791,7 @@ async function run() {
             });
         }
         else {
-            let errorMessage = "The secrets provided could not be found. Please check the service account has access to the secret UUIDs provided.";
+            let errorMessage = "The secrets provided could not be found. Please check the machine account has access to the secret UUIDs provided.";
             if (secretResponse.errorMessage) {
                 errorMessage = errorMessage + `\n\n` + secretResponse.errorMessage;
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ export async function run(): Promise<void> {
       });
     } else {
       let errorMessage =
-        "The secrets provided could not be found. Please check the service account has access to the secret UUIDs provided.";
+        "The secrets provided could not be found. Please check the machine account has access to the secret UUIDs provided.";
       if (secretResponse.errorMessage) {
         errorMessage = errorMessage + `\n\n` + secretResponse.errorMessage;
       }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Rename variants of "service accounts" to "machine accounts".

## Steps

I did the following:
- File rename changes
- Ran `npm ci`
- Ran `npm run prettier && npm run lint`
- Ran `npm test`
- Ran `npm run bundle`
