### PR TITLE
Add action input to choose between  bw cloud regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ To use the action, add a step to your GitHub workflow using the following syntax
           00000000-0000-0000-0000-000000000000 > TEST_EXAMPLE
   ```
 
+- `cloud_region`
+
+  (Optional) For usage with the cloud-hosted services on either https://vault.bitwarden.com or https://vault.bitwarden.eu
+
+  The default value will use `us`, which is the region for https://vault.bitwarden.com
+
+  To use https://vault.bitwarden.eu, set the value to `eu`
+
 - `base_url`
 
   (Optional) For self-hosted bitwarden instances provide your https://your.domain.com
@@ -95,6 +103,7 @@ TEST_EXAMPLE_2: SECRET_VALUE_FOR_bdbb16bc-0b9b-472e-99fa-af4101309076
   uses: bitwarden/sm-action@v1
   with:
     access_token: ${{ secrets.ACCESS_TOKEN }}
+    cloud_region: eu
     secrets: |
       00000000-0000-0000-0000-000000000000 > TEST_EXAMPLE
 - name: Use Secret

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   secrets:
     description: "One or more secret Ids to retrieve and the corresponding GitHub environment variable name to set"
     required: true
+  cloud_region:
+    description: "(Optional) The Bitwarden server region to use if cloud-hosted service is used. Either 'us' or 'eu'"
+    required: false
+    default: "us"
   base_url:
     description: "(Optional) For self-hosted bitwarden instances provide your https://your.domain.com"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -24745,6 +24745,7 @@ async function run() {
         const secrets = core.getMultilineInput("secrets", {
             required: true,
         });
+        const cloudRegion = core.getInput("cloud_region");
         const baseUrl = core.getInput("base_url");
         let identityUrl = core.getInput("identity_url");
         let apiUrl = core.getInput("api_url");
@@ -24755,6 +24756,19 @@ async function run() {
             }
             identityUrl = baseUrl + "/identity";
             apiUrl = baseUrl + "/api";
+        } else if (cloudRegion) {
+            let cloudBaseUrl
+            if (cloudRegion === "com") {
+                cloudBaseUrl = "bitwarden.com";
+            }
+            else if (cloudRegion === "eu") {
+                cloudBaseUrl = "bitwarden.eu";
+            }
+            else { 
+                throw TypeError("input provided for cloud_region not in expected format");
+            }
+            identityUrl = "https://identity." + cloudBaseUrl;
+            apiUrl = "https://api." + cloudBaseUrl;
         }
         if (!(0, validators_1.isValidUrl)(identityUrl)) {
             throw TypeError("input provided for identity_url not in expected format");

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ export async function run(): Promise<void> {
     const secrets: string[] = core.getMultilineInput("secrets", {
       required: true,
     });
+    const cloudRegion = core.getInput("cloud_region");
     const baseUrl: string = core.getInput("base_url");
     let identityUrl: string = core.getInput("identity_url");
     let apiUrl: string = core.getInput("api_url");
@@ -24,6 +25,20 @@ export async function run(): Promise<void> {
       }
       identityUrl = baseUrl + "/identity";
       apiUrl = baseUrl + "/api";
+    } 
+    else if (cloudRegion) {
+      let cloudBaseUrl
+      if (cloudRegion === "com") {
+        cloudBaseUrl = "bitwarden.com";
+      }
+      else if (cloudRegion === "eu") {
+        cloudBaseUrl = "bitwarden.eu";
+      }
+      else { 
+        throw TypeError("input provided for cloud_region not in expected format");
+      }
+      identityUrl = "https://identity." + cloudBaseUrl;
+      apiUrl = "https://api." + cloudBaseUrl;
     }
     if (!isValidUrl(identityUrl)) {
       throw TypeError("input provided for identity_url not in expected format");


### PR DESCRIPTION
This PR is related to my issue https://github.com/bitwarden/sm-action/issues/100 and adds a new input to the Github Action to select the vault region if the official cloud-hosted service by Bitwarden is used. 
Users can specify if by using the `cloud_region` input with either 
- `us` for https://vault.bitwarden.com/ (default)
- `eu` for https://vault.bitwarden.eu/

**Example**
```yaml
- name: Get Secrets
  uses: bitwarden/sm-action@v2
  with:
    access_token: ${{ secrets.BW_ACCESS_TOKEN }}
    cloud_region: "eu"
    secrets: |
      12345678-8e0f-4ecb-9a10-65113e8aaf66 > VAR1
      12345678-8e0f-4ecb-9a10-65113e8aaf66 > VAR2
```

This is my first time writing typescript, so please let me know if anything is wrong.