### PR TITLE
SM-1227: Improved error messages on failures

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,14 +1,42 @@
 import * as core from "@actions/core";
 import * as main from "../src/main";
+import {
+  DatumClass,
+  ResponseForAPIKeyLoginResponse,
+  ResponseForSecretsResponse,
+} from "@bitwarden/sdk-napi";
+import { randomUUID } from "crypto";
 
-// Mock the action's main function
-const runMock = jest.spyOn(main, "run");
+const INVALID_URL = "INVALID_URL";
+const TEST_ACCESS_TOKEN = randomUUID().toString();
+const TEST_SECRETS = [`\t${randomUUID().toString()} > TEST_VALUE`];
+const TEST_IDENTITY_URL = "https://identity.bitwarden.com";
+const TEST_API_URL = "https://api.bitwarden.com";
 
 // Mock the GitHub Actions core library
 let errorMock: jest.SpyInstance;
 let getInputMock: jest.SpyInstance;
-let getMultilineInput: jest.SpyInstance;
+let getMultilineInputMock: jest.SpyInstance;
 let setFailedMock: jest.SpyInstance;
+let setSecretMock: jest.SpyInstance;
+let exportVariableMock: jest.SpyInstance;
+let setOutputMock: jest.SpyInstance;
+
+// Mock the Bitwarden SDK
+const secretsClientMock = jest.fn();
+const loginWithAccessToken = jest.fn();
+const bitwardenClientMock = jest.fn().mockImplementation(() => {
+  return {
+    loginWithAccessToken: loginWithAccessToken,
+    secrets: secretsClientMock,
+  };
+});
+jest.mock("@bitwarden/sdk-napi", () => ({
+  BitwardenClient: jest.fn().mockImplementation(() => bitwardenClientMock()),
+  DeviceType: jest.requireActual("@bitwarden/sdk-napi").DeviceType,
+  ClientSettings: jest.requireActual("@bitwarden/sdk-napi").ClientSettings,
+  LogLevel: jest.requireActual("@bitwarden/sdk-napi").LogLevel,
+}));
 
 describe("action", () => {
   beforeEach(() => {
@@ -16,33 +44,263 @@ describe("action", () => {
 
     errorMock = jest.spyOn(core, "error").mockImplementation();
     getInputMock = jest.spyOn(core, "getInput").mockImplementation();
-    getMultilineInput = jest.spyOn(core, "getMultilineInput").mockImplementation();
+    getMultilineInputMock = jest.spyOn(core, "getMultilineInput").mockImplementation();
     setFailedMock = jest.spyOn(core, "setFailed").mockImplementation();
+    setSecretMock = jest.spyOn(core, "setSecret").mockImplementation();
+    exportVariableMock = jest.spyOn(core, "exportVariable").mockImplementation();
+    setOutputMock = jest.spyOn(core, "setOutput").mockImplementation();
   });
 
-  it("sets a failed status", async () => {
-    getMultilineInput.mockImplementation((name: string): string[] => {
-      switch (name) {
-        default:
-          return [];
-      }
+  describe("sets a failed status", () => {
+    it.each([
+      ["access_token", {} as Inputs, "Input required and not supplied: access_token"],
+      [
+        "secrets",
+        { accessToken: TEST_ACCESS_TOKEN } as Inputs,
+        "Input required and not supplied: secrets",
+      ],
+      [
+        "base_url",
+        { accessToken: TEST_ACCESS_TOKEN, secrets: TEST_SECRETS, baseUrl: INVALID_URL } as Inputs,
+        "input provided for base_url not in expected format",
+      ],
+      [
+        "identity_url",
+        {
+          accessToken: TEST_ACCESS_TOKEN,
+          secrets: TEST_SECRETS,
+          identityUrl: INVALID_URL,
+        } as Inputs,
+        "input provided for identity_url not in expected format",
+      ],
+      [
+        "api_url",
+        {
+          accessToken: TEST_ACCESS_TOKEN,
+          secrets: TEST_SECRETS,
+          identityUrl: TEST_IDENTITY_URL,
+          apiUrl: INVALID_URL,
+        } as Inputs,
+        "input provided for api_url not in expected format",
+      ],
+    ])("readActionInputs: invalid input %s", async (_, inputs: Inputs, errorMessage) => {
+      mockInputs(inputs);
+
+      await main.run();
+
+      expectFailed(errorMessage);
     });
 
-    getInputMock.mockImplementation((name: string): string => {
-      switch (name) {
-        default:
-          return "";
-      }
+    it("input invalid secrets syntax", async () => {
+      mockInputs({
+        accessToken: TEST_ACCESS_TOKEN,
+        secrets: ["UUID : ENV_VAR_NAME"],
+        identityUrl: TEST_IDENTITY_URL,
+        apiUrl: TEST_API_URL,
+      } as Inputs);
+
+      await main.run();
+
+      expectFailed(
+        "Error occurred when attempting to parse UUID : ENV_VAR_NAME. Expected format: <secretGuid> > <environmentVariableName>",
+      );
     });
 
-    await main.run();
-    expect(runMock).toHaveReturned();
+    it("loginWithAccessToken: authentication failed", async () => {
+      mockInputs({
+        accessToken: TEST_ACCESS_TOKEN,
+        secrets: TEST_SECRETS,
+        identityUrl: TEST_IDENTITY_URL,
+        apiUrl: TEST_API_URL,
+      } as Inputs);
+      loginWithAccessToken.mockReturnValue(
+        Promise.resolve(<ResponseForAPIKeyLoginResponse>{
+          success: false,
+          errorMessage: "Test error message",
+        }),
+      );
 
-    // Verify that all of the core library functions were called correctly
-    expect(setFailedMock).toHaveBeenNthCalledWith(
-      1,
-      "input provided for identity_url not in expected format",
-    );
-    expect(errorMock).not.toHaveBeenCalled();
+      await main.run();
+
+      expectFailed("Authentication with Bitwarden failed.\nError: Test error message");
+    });
+
+    it("secrets.getByIds: secrets not found", async () => {
+      mockInputs({
+        accessToken: TEST_ACCESS_TOKEN,
+        secrets: TEST_SECRETS,
+        identityUrl: TEST_IDENTITY_URL,
+        apiUrl: TEST_API_URL,
+      } as Inputs);
+      loginWithAccessToken.mockReturnValue(
+        Promise.resolve(<ResponseForAPIKeyLoginResponse>{
+          success: true,
+        }),
+      );
+      secretsClientMock.mockImplementation(() => {
+        return {
+          getByIds: jest.fn().mockReturnValue(<ResponseForSecretsResponse>{
+            success: false,
+            errorMessage: "Test error message",
+          }),
+        };
+      });
+
+      await main.run();
+
+      expectFailed(
+        "The secrets provided could not be found. Please check the machine account has access to the secret UUIDs provided.\nError: Test error message",
+      );
+    });
+
+    function expectFailed(errorMessage: string) {
+      expect(setFailedMock).toHaveBeenNthCalledWith(1, errorMessage);
+      expect(setFailedMock).toHaveBeenCalledTimes(1);
+      expect(errorMock).not.toHaveBeenCalled();
+      expect(setSecretMock).not.toHaveBeenCalled();
+      expect(exportVariableMock).not.toHaveBeenCalled();
+      expect(setOutputMock).not.toHaveBeenCalled();
+    }
+  });
+
+  describe("sets secrets", () => {
+    it("no secrets", async () => {
+      mockInputs({
+        accessToken: TEST_ACCESS_TOKEN,
+        secrets: [] as string[],
+        identityUrl: TEST_IDENTITY_URL,
+        apiUrl: TEST_API_URL,
+      } as Inputs);
+      loginWithAccessToken.mockReturnValue(
+        Promise.resolve(<ResponseForAPIKeyLoginResponse>{
+          success: true,
+        }),
+      );
+      secretsClientMock.mockImplementation(() => {
+        return {
+          getByIds: jest.fn().mockReturnValue(<ResponseForSecretsResponse>{
+            success: true,
+            data: {
+              data: [],
+            },
+          }),
+        };
+      });
+
+      await main.run();
+
+      expect(setFailedMock).not.toHaveBeenCalled();
+      expect(errorMock).not.toHaveBeenCalled();
+      expect(setSecretMock).not.toHaveBeenCalled();
+      expect(exportVariableMock).not.toHaveBeenCalled();
+      expect(setOutputMock).not.toHaveBeenCalled();
+    });
+
+    it("env variables exported", async () => {
+      const secretsResponse = [
+        {
+          id: randomUUID().toString(),
+          key: "TEST KEY 1",
+          value: "TEST VALUE 1",
+        } as DatumClass,
+        {
+          id: randomUUID().toString(),
+          key: "TEST KEY 2",
+          value: "TEST VALUE 2",
+        } as DatumClass,
+      ];
+
+      mockInputs({
+        accessToken: TEST_ACCESS_TOKEN,
+        secrets: [
+          `${secretsResponse[0].id} > TEST_ENV_VAR_1`,
+          `${secretsResponse[1].id} > TEST_ENV_VAR_2`,
+        ],
+        identityUrl: TEST_IDENTITY_URL,
+        apiUrl: TEST_API_URL,
+      } as Inputs);
+      loginWithAccessToken.mockReturnValue(
+        Promise.resolve(<ResponseForAPIKeyLoginResponse>{
+          success: true,
+        }),
+      );
+      secretsClientMock.mockImplementation(() => {
+        return {
+          getByIds: jest.fn().mockReturnValue(<ResponseForSecretsResponse>{
+            success: true,
+            data: {
+              data: secretsResponse,
+            },
+          }),
+        };
+      });
+
+      await main.run();
+
+      expect(setFailedMock).not.toHaveBeenCalled();
+      expect(errorMock).not.toHaveBeenCalled();
+      expect(setSecretMock).toHaveBeenNthCalledWith(1, secretsResponse[0].value);
+      expect(setSecretMock).toHaveBeenNthCalledWith(2, secretsResponse[1].value);
+      expect(setSecretMock).toHaveBeenCalledTimes(2);
+      expect(exportVariableMock).toHaveBeenNthCalledWith(
+        1,
+        "TEST_ENV_VAR_1",
+        secretsResponse[0].value,
+      );
+      expect(exportVariableMock).toHaveBeenNthCalledWith(
+        2,
+        "TEST_ENV_VAR_2",
+        secretsResponse[1].value,
+      );
+      expect(exportVariableMock).toHaveBeenCalledTimes(2);
+      expect(setOutputMock).toHaveBeenNthCalledWith(1, "TEST_ENV_VAR_1", secretsResponse[0].value);
+      expect(setOutputMock).toHaveBeenNthCalledWith(2, "TEST_ENV_VAR_2", secretsResponse[1].value);
+      expect(setOutputMock).toHaveBeenCalledTimes(2);
+    });
   });
 });
+
+type Inputs = {
+  accessToken?: string;
+  secrets?: string[];
+  baseUrl?: string;
+  identityUrl?: string;
+  apiUrl?: string;
+};
+
+function mockInputs(inputs: Inputs) {
+  const { accessToken, secrets, baseUrl, identityUrl, apiUrl } = inputs;
+
+  getInputMock.mockImplementation(
+    (name: string, options?: { required?: boolean }): string | undefined => {
+      const value = {
+        access_token: accessToken,
+        base_url: baseUrl,
+        identity_url: identityUrl,
+        api_url: apiUrl,
+      }[name];
+
+      // Error from core.getInput is thrown if the input is required and not supplied
+      if (options?.required && !value) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+
+      return value;
+    },
+  );
+
+  getMultilineInputMock.mockImplementation(
+    (name: string, options?: { required?: boolean }): string[] | undefined => {
+      const value = {
+        secrets: secrets,
+      }[name];
+
+      // Error from core.getMultilineInput is thrown if the input is required and not supplied
+      if (options?.required && !value) {
+        throw new Error(`Input required and not supplied: ${name}`);
+      }
+
+      return value;
+    },
+  );
+}

--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -23,6 +23,37 @@ test("parseSecretInput: test parser no spaces", () => {
   expect(t).not.toThrow(TypeError);
 });
 
+test("parseSecretInput: test parser bad input", () => {
+  const t = () => {
+    const secrets: string[] = [
+      "bdbb16bc-0b9b-472e-99fa-af4101309076",
+      "bdbb16bc-0b9b-472e-99fa-af4101309076 : TEST_NAME",
+      "bdbb16ac-0b9b-472e-99fa-af4101309076 > TEST_NAME2",
+    ];
+    parseSecretInput(secrets);
+  };
+  expect(t).toThrow(
+    new TypeError(
+      "Error occurred when attempting to parse bdbb16bc-0b9b-472e-99fa-af4101309076. Expected format: <secretGuid> > <environmentVariableName>",
+    ),
+  );
+});
+
+test("parseSecretInput: test parser bad Guid", () => {
+  const t = () => {
+    const secrets: string[] = [
+      "bdbb16bc-0b9b-472e-99fa > TEST_NAME",
+      "bdbb16ac-0b9b-472e-99fa-af4101309076 > TEST_NAME2",
+    ];
+    parseSecretInput(secrets);
+  };
+  expect(t).toThrow(
+    new TypeError(
+      "Error occurred when attempting to parse bdbb16bc-0b9b-472e-99fa > TEST_NAME. Id is not a valid GUID",
+    ),
+  );
+});
+
 test("parseSecretInput: test parser bad env name", () => {
   const t = () => {
     const secrets: string[] = [
@@ -31,20 +62,22 @@ test("parseSecretInput: test parser bad env name", () => {
     ];
     parseSecretInput(secrets);
   };
-  expect(t).toThrow(TypeError);
   expect(t).toThrow(
-    "Error occurred when attempting to parse bdbb16bc-0b9b-472e-99fa-af4101309076 > ",
+    new TypeError(
+      "Error occurred when attempting to parse bdbb16bc-0b9b-472e-99fa-af4101309076 > . Environment variable name is not valid",
+    ),
   );
 });
 
-test("parseSecretInput: test parser bad input", () => {
+test("parseSecretInput: test parser duplicate environment variabled", () => {
   const t = () => {
     const secrets: string[] = [
-      "bdbb16bc-0b9b-472e-99fa-af4101309076",
-      "bdbb16ac-0b9b-472e-99fa-af4101309076 > TEST_NAME2",
+      "bdbb16bc-0b9b-472e-99fa-af4101309076 > TEST_NAME",
+      "bdbb16ac-0b9b-472e-99fa-af4101309076 > TEST_NAME",
     ];
     parseSecretInput(secrets);
   };
-  expect(t).toThrow(TypeError);
-  expect(t).toThrow("Error occurred when attempting to parse bdbb16bc-0b9b-472e-99fa-af4101309076");
+  expect(t).toThrow(
+    new TypeError("Environmental variable names provided are not unique, names must be unique"),
+  );
 });

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
   base_url:
     description: "(Optional) For self-hosted bitwarden instances provide your https://your.domain.com"
     required: false
+    default: ""
   identity_url:
     description: "(Optional) For self-hosted bitwarden instances provide your https://your.domain.com/identity"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -25025,8 +25025,7 @@ async function getBitwardenClient(inputs) {
         userAgent: "bitwarden/sm-action",
         deviceType: sdk_napi_1.DeviceType.SDK,
     };
-    const logLevel = core.isDebug() ? 1 /* LogLevel.Debug */ : 2 /* LogLevel.Info */;
-    const client = new sdk_napi_1.BitwardenClient(settings, logLevel);
+    const client = new sdk_napi_1.BitwardenClient(settings, 2 /* LogLevel.Info */);
     const result = await client.loginWithAccessToken(inputs.accessToken);
     if (!result.success) {
         throw Error(`Authentication with Bitwarden failed.\nError: ${result.errorMessage}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,9 +93,7 @@ async function getBitwardenClient(inputs: Inputs): Promise<BitwardenClient> {
     deviceType: DeviceType.SDK,
   };
 
-  const logLevel = core.isDebug() ? LogLevel.Debug : LogLevel.Info;
-
-  const client = new BitwardenClient(settings, logLevel);
+  const client = new BitwardenClient(settings, LogLevel.Info);
   const result = await client.loginWithAccessToken(inputs.accessToken);
   if (!result.success) {
     throw Error(`Authentication with Bitwarden failed.\nError: ${result.errorMessage}`);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1227

## 📔 Objective

Improve error messages on failures.

### Changes:
- `action.yml`: Added default value to `base_url`, since the docs specifies that all `required: false` inputs needs a default value.
- `src/main.ts`: 
  - `access_token` input is required - consistency with `action.yml`
  - Added error message from `BitwardenClient.loginWithAccessToken` response into the error handling.
  - Debug logging when GH Action runs in debug.
  - Refactoring
  - Unit Tests coverage
- `src/parser.ts`:
  - Added parsing error messages from various parsing error scenarios as part into error handling.
  - Unit Test coverage

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation
  team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
  issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes