### PR TITLE
BRE-663 - Update verify input version step of Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Get latest release version
         id: get-latest-release
         run: |
-          latest_version=$(curl --silent "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r '.tag_name')
+          LATEST_RELEASE_VERSION=$(curl --silent "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq -r '.tag_name')
           echo "Latest release version is $latest_version"
-          echo "latest_version=$latest_version" >> $GITHUB_OUTPUT
+          echo "latest_version=${LATEST_RELEASE_VERSION#v}" >> $GITHUB_OUTPUT
 
       - name: Get current action version
         id: current-version
@@ -46,17 +46,17 @@ jobs:
 
       - name: Verify input version
         env:
-          CURRENT_VERSION: v${{ steps.current-version.outputs.version }}
-          LATEST_VERSION: ${{ steps.get-latest-release.outputs.latest_version }}
+          CURRENT_PKG_VERSION: ${{ steps.current-version.outputs.version }}
+          LATEST_RELEASE_VERSION: ${{ steps.get-latest-release.outputs.latest_version }}
         run: |
           # Error if version has not changed.
-          if [[ "$LATEST_VERSION" == "$CURRENT_VERSION" ]]; then
+          if [[ "$LATEST_RELEASE_VERSION" == "$CURRENT_PKG_VERSION" ]]; then
             echo "Version has not changed."
             exit 1
           fi
 
           # Check if version is newer.
-          printf '%s\n' "${CURRENT_VERSION}" "${LATEST_VERSION}" | sort -C -V
+          printf '%s\n' "${LATEST_RELEASE_VERSION}" "${CURRENT_PKG_VERSION}" | sort -C -V
           if [ $? -eq 0 ]; then
             echo "Version check successful."
           else


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-663](https://bitwarden.atlassian.net/browse/BRE-663?atlOrigin=eyJpIjoiNDJmNjMxZWQzMzE1NGExYWE2MzgxODQyYWFiMTAyMGQiLCJwIjoiaiJ9)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR updates the logic of the `Verify input version` step of the Release workflow.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-663]: https://bitwarden.atlassian.net/browse/BRE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ