### PR TITLE
Adding option to avoid setting secrets as environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "(Optional) For self-hosted bitwarden instances provide your https://your.domain.com/api"
     required: false
     default: ""
+  set_env:
+    description: "(Optional) Set the secrets as environment variables. Defaults to true"
+    required: false
+    default: "true"
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,9 @@ export async function run(): Promise<void> {
         const secretInput = secretInputs.find((secretInput) => secretInput.id === secret.id);
         if (secretInput) {
           core.setSecret(secret.value);
-          core.exportVariable(secretInput.outputEnvName, secret.value);
+          if(inputs.setEnv) {
+            core.exportVariable(secretInput.outputEnvName, secret.value);
+          }
           core.setOutput(secretInput.outputEnvName, secret.value);
         }
       });
@@ -50,6 +52,7 @@ type Inputs = {
   secrets: string[];
   identityUrl: string;
   apiUrl: string;
+  setEnv: boolean;
 };
 
 function readInputs(): Inputs {
@@ -61,6 +64,7 @@ function readInputs(): Inputs {
   });
   const cloudRegion: string = core.getInput("cloud_region");
   const baseUrl: string = core.getInput("base_url");
+  const setEnv: boolean = core.getBooleanInput("set_env");
   let identityUrl: string = core.getInput("identity_url");
   let apiUrl: string = core.getInput("api_url");
 
@@ -118,6 +122,7 @@ function readInputs(): Inputs {
     secrets,
     identityUrl,
     apiUrl,
+    setEnv
   };
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

Example

## 📔 Objective

Adds an option `set_env` to provide for the ability to avoid setting the secrets into the environment.
Defaulting to `true` allows for backwards compatibility where this is currently relied.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
