### PR TITLE
fix: update renovate config to not use step intervals

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
   "timezone": "America/Chicago",
-  "schedule": ["* 0-4 1-7 2/2 1"],
+  "schedule": ["* 6 1-7 2,4,6,8,10,12 1"],
   "enabledManagers": ["github-actions", "cargo"],
   "packageRules": [
     {


### PR DESCRIPTION
## 📔 Objective

> Iterating on trying to fix the renovate schedule syntax. Logs say the syntax being replaced is invalid.
